### PR TITLE
Add solution: Subarray Divisibility (CSES 1662)

### DIFF
--- a/2_sorting_searching/subarray_divisibility.cpp
+++ b/2_sorting_searching/subarray_divisibility.cpp
@@ -1,0 +1,40 @@
+// CSES 1662: Subarray Divisibility
+// Counts subarrays with sum % n == 0 using prefix remainders.
+
+#include <bits/stdc++.h>
+using namespace std;
+
+typedef long long ll;
+#define mod 1000000007  // (not used here, kept to match repo template)
+
+int main() {
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+
+    ll n;
+    if (!(cin >> n)) return 0;
+
+    vector<ll> freq(n, 0);
+    // freq[r] = how many prefix sums had remainder r so far
+    // Start with empty prefix remainder 0 to count subarrays starting at index 1
+    freq[0] = 1;
+
+    ll pref = 0;
+    ll ans = 0;
+
+    for (ll i = 0; i < n; ++i) {
+        ll x; 
+        cin >> x;
+        pref += x;
+
+        ll r = pref % n;
+        if (r < 0) r += n;   // normalize for negative values
+
+        ans += freq[r];     // each earlier same remainder forms a valid subarray
+        ++freq[r];
+    }
+
+    cout << ans << '\n';
+    return 0;
+}


### PR DESCRIPTION
## 🎯 Problem Information
Problem Name: Subarray Divisibility
CSES Link: https://cses.fi/problemset/task/1662
Category: Sorting and Searching
Estimated Difficulty: Medium

## 📝 Description
Brief description of what this PR accomplishes:This PR adds a new solution for CSES Problem – Subarray Divisibility (1662) under the 2_sorting_searching category.
The solution counts the number of subarrays whose sum is divisible by n using the prefix remainder frequency method.
This is an O(n) optimized solution and handles negative numbers gracefully.

## 🧩 Solution Approach
- **Algorithm Used**: Prefix sum modulo frequency counting.
We keep track of the remainder of the prefix sums modulo n.
If the same remainder has occurred before, it means there exists a subarray between those occurrences whose sum is divisible by n.
- **Time Complexity**: O(n)
- **Space Complexity**: O(n)
- **Key Insights**: For a subarray l..r to be divisible by n, prefix[r] % n == prefix[l-1] % n.

Start with freq[0] = 1 to account for subarrays starting at index 1.
Normalize remainders for negative numbers to avoid incorrect indexing.
Each repeated remainder contributes c choose 2 subarrays, but we accumulate incrementally to avoid a second pass.
