### PR TITLE
Add solution: Nested Ranges Count (CSES 2169)

### DIFF
--- a/2_sorting_searching/nested_ranges_count_alt.cpp
+++ b/2_sorting_searching/nested_ranges_count_alt.cpp
@@ -1,0 +1,84 @@
+// CSES 2169 - Nested Ranges Count
+// Outputs: line 1 = how many ranges contain each range
+//          line 2 = how many ranges each range contains
+
+#include <bits/stdc++.h>
+using namespace std;
+
+typedef long long ll;
+
+// Fenwick / BIT for prefix sums on 1..N
+struct Fenwick {
+    int n; vector<ll> bit;
+    Fenwick(int n=0): n(n), bit(n+1,0) {}
+    void reset(int m) { n=m; bit.assign(n+1,0); }
+    void add(int idx, ll val){ for(; idx<=n; idx+=idx&-idx) bit[idx]+=val; }
+    ll sum(int idx){ ll s=0; for(; idx>0; idx-=idx&-idx) s+=bit[idx]; return s; }
+};
+
+int main(){
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+
+    int n; 
+    if(!(cin >> n)) return 0;
+
+    struct R { ll l,r; int id; };
+    vector<R> a(n);
+    vector<ll> allR; allR.reserve(n);
+    for(int i=0;i<n;i++){
+        cin >> a[i].l >> a[i].r;
+        a[i].id = i;
+        allR.push_back(a[i].r);
+    }
+
+    // sort by l asc, r desc
+    sort(a.begin(), a.end(), [](const R& A, const R& B){
+        if (A.l != B.l) return A.l < B.l;
+        return A.r > B.r;
+    });
+
+    // coordinate-compress r
+    sort(allR.begin(), allR.end());
+    allR.erase(unique(allR.begin(), allR.end()), allR.end());
+    auto ridx = [&](ll r){
+        return int(lower_bound(allR.begin(), allR.end(), r) - allR.begin()) + 1; // 1-based
+    };
+
+    vector<ll> contain_me(n,0), i_contain(n,0); // answers in input order
+    Fenwick fw((int)allR.size());
+
+    // 1) how many contain me: sweep left -> right, count r >= r_i among seen
+    fw.reset((int)allR.size());
+    for(int i=0;i<n;i++){
+        int ri = ridx(a[i].r);
+        ll seen = i; // number of ranges already processed
+        ll leq = fw.sum(ri-1); // those with r < r_i
+        contain_me[a[i].id] = seen - leq; // r >= r_i
+        fw.add(ri, 1);
+    }
+
+    // 2) how many I contain: sweep right -> left, count r <= r_i among to the right
+fw.reset((int)allR.size());
+for (int i = n - 1; i >= 0; i--) {
+    int ri = ridx(a[i].r);
+    // count how many future intervals have r <= r_i
+    i_contain[a[i].id] = fw.sum(ri);
+    // add current interval AFTER counting, so it won't count itself
+    fw.add(ri, 1);
+}
+
+    // output
+    for(int i=0;i<n;i++){
+        if(i) cout << ' ';
+        cout << contain_me[i];
+    }
+    cout << '\n';
+    for(int i=0;i<n;i++){
+        if(i) cout << ' ';
+        cout << i_contain[i];
+    }
+    cout << '\n';
+    return 0;
+}


### PR DESCRIPTION
## 🎯 Problem Information
Problem Name: Nested Ranges Count
CSES Link: https://cses.fi/problemset/task/2169
Category: Sorting and Searching
Estimated Difficulty: Medium

## 📝 Description
Brief description of what this PR accomplishes:This PR adds a solution for CSES Problem – Nested Ranges Count (2169) under the 2_sorting_searching category.
The program calculates, for each interval:
How many other intervals contain it.
How many intervals it contains.
The solution uses sorting and a Fenwick Tree (Binary Indexed Tree) to achieve efficient counting in O(n log n) time.

## 🧩 Solution Approach
- **Algorithm Used**: Sort the intervals by starting point ascending and ending point descending.
Coordinate-compress the r values.
Sweep left to right with a Fenwick tree to count how many previously seen intervals have r ≥ r_i → gives contain_me.
Sweep right to left to count how many intervals to the right have r ≤ r_i → gives i_contain.

Restore results in original input order.
- **Time Complexity**: O(nLogn)
- **Space Complexity**: O(n)
- **Key Insights**: Sorting by (l asc, r desc) ensures containment relationships are processed in the correct order.
A Fenwick tree allows efficient prefix sum queries and updates for range counting.
Coordinate compression keeps the tree size small and avoids dealing with large numbers directly.
Sweeping in opposite directions naturally avoids self-counting and handles duplicates.

